### PR TITLE
When ordering a playlist that isn't set to Manual, display a friendly warning

### DIFF
--- a/src/components/videolist/PlaylistOrderErrorModal.jsx
+++ b/src/components/videolist/PlaylistOrderErrorModal.jsx
@@ -1,0 +1,28 @@
+export default function PlaylistOrderErrorModal({ 
+  isOpen, 
+  onClose 
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-800 rounded-lg p-4 sm:p-6 max-w-md w-full">
+        <h3 className="text-lg sm:text-xl font-bold mb-4 text-red-500">Playlist Order Error</h3>
+        <p className="text-gray-300 mb-4 text-sm sm:text-base">
+          Before changing the order of the videos in this playlist, the playlist order on YouTube must be set to <span className="font-semibold">Manual</span>.
+        </p>
+        <p className="text-gray-400 mb-6 text-xs sm:text-sm">
+          To fix this, go to YouTube, open this playlist, and select "Manual" from the dropdown at the top of the playlist.
+        </p>
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="bg-orange-600 hover:bg-orange-700 text-white px-6 py-3 sm:py-2 rounded text-sm sm:text-base touch-manipulation"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/videolist/VideoList.jsx
+++ b/src/components/videolist/VideoList.jsx
@@ -24,6 +24,7 @@ import SortableVideoCard from './SortableVideoCard';
 import MoveVideoModal from './MoveVideoModal';
 import CopyVideoModal from './CopyVideoModal';
 import DeleteVideoModal from './DeleteVideoModal';
+import PlaylistOrderErrorModal from './PlaylistOrderErrorModal';
 import Snackbar from './Snackbar';
 import { useVideoData } from './hooks/useVideoData';
 import { useVideoOperations } from './hooks/useVideoOperations';
@@ -58,6 +59,7 @@ function VideoList({ playlist, onBack }) {
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [showCopyModal, setShowCopyModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showPlaylistOrderErrorModal, setShowPlaylistOrderErrorModal] = useState(false);
   const [videoToDelete, setVideoToDelete] = useState(null);
   const [selectedTargetPlaylist, setSelectedTargetPlaylist] = useState(null);
   const [selectedCopyPlaylists, setSelectedCopyPlaylists] = useState([]);
@@ -147,7 +149,15 @@ function VideoList({ playlist, onBack }) {
       setSnackbar({ message: 'Video order updated', type: 'success', isOpen: true });
     } catch (err) {
       console.error('Error reordering video:', err);
-      setSnackbar({ message: `Failed to reorder: ${err.message}`, type: 'error', isOpen: true });
+      
+      // Check if error is about playlist not being set to Manual order
+      const errorMessage = err.message.toLowerCase();
+      if (errorMessage.includes('manual') || errorMessage.includes('order') || errorMessage.includes('playlist order')) {
+        setShowPlaylistOrderErrorModal(true);
+      } else {
+        setSnackbar({ message: `Failed to reorder: ${err.message}`, type: 'error', isOpen: true });
+      }
+      
       // Revert on error
       loadVideos();
     } finally {
@@ -279,6 +289,11 @@ function VideoList({ playlist, onBack }) {
           setVideoToDelete(null);
         }}
         isDeleting={operating}
+      />
+
+      <PlaylistOrderErrorModal
+        isOpen={showPlaylistOrderErrorModal}
+        onClose={() => setShowPlaylistOrderErrorModal(false)}
       />
 
       <button


### PR DESCRIPTION
Add friendly warning for when a playlist that isn't set to 'Manual' is reordered in the app